### PR TITLE
fix(validate): do not panic with field errors on non-struct types

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -83,7 +83,7 @@ func (s *Validator) validate(path []string, data interface{}) error {
 			e := &Error{}
 			if ok := errors.As(err, &e); ok {
 				field := e.Field
-				if field != "" {
+				if field != "" && d.Kind() == reflect.Struct {
 					if sf, ok := d.Type().FieldByName(e.Field); ok {
 						field = s.fieldName(sf)
 					}


### PR DESCRIPTION
When validating non-struct types, we should not try and convert field values in
errors, because there is no struct field to lookup. Hence this fix stops a panic
from happening.

It is up to the Validate() method itself to provide the correct and final field
value when validating non-struct types.